### PR TITLE
fix: Checkout from develop with full history in release workflow

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
 
       - name: Create Draft Release
         id: draft-release


### PR DESCRIPTION
- Change checkout ref from implicit to explicit 'develop' branch
- Add fetch-depth: 0 to get full git history
- Fixes "no history in common with master" error when creating PR